### PR TITLE
Fixate the k8gb version to make the scripts reproducible in the future

### DIFF
--- a/chapter4/k8gb-example/k8gb/k8gb-buf-values.yaml
+++ b/chapter4/k8gb-example/k8gb/k8gb-buf-values.yaml
@@ -2,6 +2,7 @@ global:
   imagePullSecrets: []
 k8gb:
   imageRepo: absaoss/k8gb
+  imageTag: v0.8.7
   dnsZone: "gb.foowidgets.k8s" # dnsZone controlled by gslb
   edgeDNSZone: "foowidgets.k8s" # main zone which would contain gslb zone to delegate
   edgeDNSServer: "10.2.1.14" # use this DNS server as a main resolver to enable cross k8gb DNS based communication

--- a/chapter4/k8gb-example/k8gb/k8gb-nyc-values.yaml
+++ b/chapter4/k8gb-example/k8gb/k8gb-nyc-values.yaml
@@ -2,6 +2,7 @@ global:
   imagePullSecrets: []
 k8gb:
   imageRepo: absaoss/k8gb
+  imageTag: v0.8.7
   dnsZone: "gb.foowidgets.k8s" # dnsZone controlled by gslb
   edgeDNSZone: "foowidgets.k8s" # main zone which would contain gslb zone to delegate
   edgeDNSServer: "10.2.1.14" # use this DNS server as a main resolver to enable cross k8gb DNS based communication


### PR DESCRIPTION
We don't plan to break the API anytime soon, but just to be on the safe side. if the tag is not specified, the chart's version [is used](https://github.com/k8gb-io/k8gb/blob/v0.8.7/chart/k8gb/templates/operator.yaml#L23) (we release both at the same time). So effectively it will be the same as `:latest` because the deploy script [updates](https://github.com/PacktPublishing/Kubernetes---An-Enterprise-Guide-2E/blob/main/chapter4/k8gb-example/k8gb/deploy-k8gb-buf.sh#L10) the helm chart each time.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>